### PR TITLE
Changed trillions translation in ukrainian. Minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Here we retrieve a list of all supported languages:
 from-numeric-word-form('languages').sort
 ```
 ```
-# (azerbaijani azərbaycan bulgarian czech english español français french greek japanese korean koremutake persian polish polski portuguese português russian spanish ukrainian český ελληνικά български руский український 日本語 한국어)
+# (azerbaijani azərbaycan bulgarian czech english español français french greek japanese korean koremutake persian polish polski portuguese português russian spanish ukrainian český ελληνικά български русский українська 日本語 한국어)
 ```
 
 **Remark:** In the list above some languages appear twice, with both their English and native names.

--- a/lib/Lingua/NumericWordForms/NumericWordForms.rakumod
+++ b/lib/Lingua/NumericWordForms/NumericWordForms.rakumod
@@ -62,8 +62,8 @@ my %langToActionExtended =
     "български"      => Lingua::NumericWordForms::Actions::Bulgarian::WordedNumberSpec,
     "polski"         => Lingua::NumericWordForms::Actions::Polish::WordedNumberSpec,
     "português"      => Lingua::NumericWordForms::Actions::Portuguese::WordedNumberSpec,
-    "руский"         => Lingua::NumericWordForms::Actions::Russian::WordedNumberSpec,
-    "український"    => Lingua::NumericWordForms::Actions::Ukrainian::WordedNumberSpec,
+    "русский"        => Lingua::NumericWordForms::Actions::Russian::WordedNumberSpec,
+    "українська"     => Lingua::NumericWordForms::Actions::Ukrainian::WordedNumberSpec,
     "日本語"          => Lingua::NumericWordForms::Actions::Japanese::WordedNumberSpec,
     "한국어"           => Lingua::NumericWordForms::Actions::Korean::WordedNumberSpec;
 
@@ -96,8 +96,8 @@ my %langToRoleExtended =
     "български"      => Lingua::NumericWordForms::Roles::Bulgarian::WordedNumberSpec,
     "polski"         => Lingua::NumericWordForms::Roles::Polish::WordedNumberSpec,
     "português"      => Lingua::NumericWordForms::Roles::Portuguese::WordedNumberSpec,
-    "руский"         => Lingua::NumericWordForms::Roles::Russian::WordedNumberSpec,
-    "український"    => Lingua::NumericWordForms::Roles::Ukrainian::WordedNumberSpec,
+    "русский"        => Lingua::NumericWordForms::Roles::Russian::WordedNumberSpec,
+    "українська"     => Lingua::NumericWordForms::Roles::Ukrainian::WordedNumberSpec,
     "日本語"          => Lingua::NumericWordForms::Roles::Japanese::WordedNumberSpec,
     "한국어"           => Lingua::NumericWordForms::Roles::Korean::WordedNumberSpec;
 

--- a/lib/Lingua/NumericWordForms/Roles/Ukrainian/WordedNumberSpec.rakumod
+++ b/lib/Lingua/NumericWordForms/Roles/Ukrainian/WordedNumberSpec.rakumod
@@ -43,7 +43,7 @@ role Lingua::NumericWordForms::Roles::Ukrainian::WordedNumberSpec
     token name_of_10000:sym<Ukrainian> {'десять тисяч'}
     token name_of_1000000:sym<Ukrainian> {'мільйон' | 'мільйонів' | 'мільйони'}
     token name_of_bil:sym<Ukrainian>     {'мільярд' | 'мільярдів' | 'мільярди'}
-    token name_of_tril:sym<Ukrainian>    {'більйон' | 'більйонів' | 'більйони'}
+    token name_of_tril:sym<Ukrainian>    {'трильйон' | 'трильйонів' | 'трильйони'}
 
-    token worded-number-and-conjunction:sym<Ukrainian> {'и'}
+    token worded-number-and-conjunction:sym<Ukrainian> {'та'}
 }


### PR DESCRIPTION
* Ukrainian language uses Short scale for numbering hence trillions translation.
* Minor syntax fixes.